### PR TITLE
Corrige o bug

### DIFF
--- a/src/algoritmos/BuscaProfundidade.java
+++ b/src/algoritmos/BuscaProfundidade.java
@@ -64,6 +64,8 @@ public class BuscaProfundidade {
     }
 
     public void executarDFS(int novaOrigem) {
+        this.vertices = grafo.getListaVertices();
+
         if (novaOrigem < 0 || novaOrigem >= vertices.size()) {
             throw new IllegalArgumentException("Invalid origin index: " + novaOrigem);
         }


### PR DESCRIPTION
Garante que o vértice é atualizado antes de executar a busca em profundidade.